### PR TITLE
Bump elm-sha1 dependency

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -9,7 +9,7 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "TSFoster/elm-sha1": "1.0.0 <= v < 2.0.0",
+        "TSFoster/elm-sha1": "1.0.2 <= v < 2.0.0",
         "elm/bytes": "1.0.7 <= v < 2.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",
         "ktonon/elm-word": "2.1.2 <= v < 3.0.0",


### PR DESCRIPTION
Hi!

Thanks to @colinta, elm-sha1 has been updated to fix the issue he encountered regarding 311 byte input. This PR bumps the dependency to the new version. I've also added a section in [elm-sha1's README](https://github.com/TSFoster/elm-sha1#important-incorrect-calculation-in-older-versions), you may want to add a similar note.