### PR TITLE
Update to new major version of elm-sha1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-elm-stuff
-tests/elm-verify-examples.json
+/elm-stuff
+/tests/VerifyExamples/

--- a/README.md
+++ b/README.md
@@ -47,3 +47,15 @@ cryptographically strong. Use this package to interoperate with systems that
 already uses HMAC SHA-1 and not for implementing new systems.
 
 There are stronger cryptographic algorithms like HMAC SHA-2, and [this](https://github.com/ktonon/elm-crypto) Elm package implements it.
+
+## Testing
+
+This package uses doc tests, which can be tested using [elm-verify-examples].
+To run all tests (assuming `elm-test` and `elm-verify-examples` are installed):
+
+```bash
+cd elm-hmac-sha1
+elm-verify-examples --fail-on-warn && elm-test
+```
+
+[elm-verify-examples]: https://github.com/stoeffel/elm-verify-examples

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Some API's use the HMAC SHA-1 as Authentication, like Amazon or Twitter.
 
 ```elm
 import HmacSha1
+import HmacSha1.Key as Key exposing (Key)
 
 canonicalString : String
 canonicalString =
@@ -33,7 +34,11 @@ canonicalString =
         , "Wed, 02 Nov 2016 17:26:52 GMT"
         ]
 
-HmacSha1.digest "verify-secret" canonicalString
+appKey : Key
+appKey =
+    Key.fromString "verify-secret"
+
+HmacSha1.fromString appKey canonicalString
     |> HmacSha1.toBase64
 --> "nLet/JEZG9CRXHScwaQ/na4vsKQ="
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ canonicalString =
 
 HmacSha1.digest "verify-secret" canonicalString
     |> HmacSha1.toBase64
---> Ok "nLet/JEZG9CRXHScwaQ/na4vsKQ="
+--> "nLet/JEZG9CRXHScwaQ/na4vsKQ="
 ```
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ import HmacSha1
 
 canonicalString : String
 canonicalString =
-  ["application/json", "", "/account", "Wed, 02 Nov 2016 17:26:52 GMT"]
-    |> String.join ","
+    String.join ","
+        [ "application/json"
+        , ""
+        , "/account"
+        , "Wed, 02 Nov 2016 17:26:52 GMT"
+        ]
 
 HmacSha1.digest "verify-secret" canonicalString
-  |> HmacSha1.toBase64
+    |> HmacSha1.toBase64
 --> Ok "nLet/JEZG9CRXHScwaQ/na4vsKQ="
 ```
 

--- a/elm.json
+++ b/elm.json
@@ -9,7 +9,7 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "TSFoster/elm-sha1": "1.0.0 <= v < 2.0.0",
+        "TSFoster/elm-sha1": "1.0.2 <= v < 2.0.0",
         "elm/bytes": "1.0.7 <= v < 2.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",
         "ktonon/elm-word": "2.1.2 <= v < 3.0.0",

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "romariolopezc/elm-hmac-sha1",
     "summary": "Compute HMAC with SHA-1 hash function",
     "license": "MIT",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "exposed-modules": [
         "HmacSha1"
     ],

--- a/elm.json
+++ b/elm.json
@@ -9,11 +9,9 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "TSFoster/elm-sha1": "1.0.2 <= v < 2.0.0",
-        "elm/bytes": "1.0.7 <= v < 2.0.0",
-        "elm/core": "1.0.0 <= v < 2.0.0",
-        "ktonon/elm-word": "2.1.2 <= v < 3.0.0",
-        "waratuman/elm-coder": "3.0.0 <= v < 4.0.0"
+        "TSFoster/elm-sha1": "2.0.0 <= v < 3.0.0",
+        "elm/bytes": "1.0.8 <= v < 2.0.0",
+        "elm/core": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.2.0 <= v < 2.0.0"

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "romariolopezc/elm-hmac-sha1",
     "summary": "Compute HMAC with SHA-1 hash function",
     "license": "MIT",
-    "version": "2.0.2",
+    "version": "3.0.0",
     "exposed-modules": [
         "HmacSha1"
     ],

--- a/elm.json
+++ b/elm.json
@@ -5,7 +5,8 @@
     "license": "MIT",
     "version": "3.0.0",
     "exposed-modules": [
-        "HmacSha1"
+        "HmacSha1",
+        "HmacSha1.Key"
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {

--- a/src/HmacSha1.elm
+++ b/src/HmacSha1.elm
@@ -35,11 +35,11 @@ type Key
 
     digest "key" "The quick brown fox jumps over the lazy dog"
         |> toHex
-    --> Ok "DE7C9B85B8B78AA6BC8A7A36F70A90701C9DB4D9"
+    --> "de7c9b85b8b78aa6bc8a7a36f70a90701c9db4d9"
 
     digest "key" "The quick brown fox jumps over the lazy dog"
         |> toBase64
-    --> Ok "3nybhbi3iqa8ino29wqQcBydtNk="
+    --> "3nybhbi3iqa8ino29wqQcBydtNk="
 
 -}
 digest : String -> String -> Digest
@@ -76,26 +76,26 @@ toIntList (Digest data) =
     SHA1.toByteValues data
 
 
-{-| Convert a Digest into a base64 String Result
+{-| Convert a Digest into a base64 String
 
     toBase64 (digest "key" "message")
-    --> Ok "IIjfdNXyFGtIFGyvSWU3fp0L46Q="
+    --> "IIjfdNXyFGtIFGyvSWU3fp0L46Q="
 
 -}
-toBase64 : Digest -> Result String String
+toBase64 : Digest -> String
 toBase64 (Digest data) =
-    Ok (SHA1.toBase64 data)
+    SHA1.toBase64 data
 
 
-{-| Convert a Digest into a base16 String Result
+{-| Convert a Digest into a base16 String
 
     toHex (digest "key" "message")
-    --> Ok "2088DF74D5F2146B48146CAF4965377E9D0BE3A4"
+    --> "2088df74d5f2146b48146caf4965377e9d0be3a4"
 
 -}
-toHex : Digest -> Result String String
+toHex : Digest -> String
 toHex (Digest data) =
-    Ok (String.toUpper (SHA1.toHex data))
+    SHA1.toHex data
 
 
 

--- a/src/HmacSha1.elm
+++ b/src/HmacSha1.elm
@@ -58,8 +58,12 @@ digest key message =
 You can use this to map it to your own representations. I use it to convert it to
 Base16 and Base64 string representations.
 
-    toBytes (digest "key" "message")
-    --> <80 bytes>
+    import Bytes
+
+    digest "key" "message"
+        |> toBytes
+        |> Bytes.width
+    --> 20
 
 -}
 toBytes : Digest -> Bytes
@@ -71,8 +75,7 @@ toBytes (Digest data) =
 Byte representation as a list of integers.
 
     toIntList (digest "key" "message")
-        |> toIntList
-    --> [32,136,223,116,213,242,20,107,72,20,108,175,73,101,55,126,157,11,227,164]
+    --> [32, 136, 223, 116, 213, 242, 20, 107, 72, 20, 108, 175, 73, 101, 55, 126, 157, 11, 227, 164]
 
 -}
 toIntList : Digest -> List Int
@@ -82,14 +85,9 @@ toIntList (Digest data) =
 
 {-| Convert a Digest into a base64 String Result
 
-    case toBase64 (digest "key" "message") of
-        Ok base64String ->
-            "Base64 string: " ++ base64String
 
-        Err err ->
-            "Failed to convert the digest"
-
-    --> Base64 string: IIjfdNXyFGtIFGyvSWU3fp0L46Q=
+    toBase64 (digest "key" "message")
+    --> Ok "IIjfdNXyFGtIFGyvSWU3fp0L46Q="
 
 -}
 toBase64 : Digest -> Result String String
@@ -99,14 +97,8 @@ toBase64 (Digest data) =
 
 {-| Convert a Digest into a base16 String Result
 
-    case toHex (digest "key" "message") of
-        Ok base16String ->
-            "Hex string: " ++ base16String
-
-        Err err ->
-            "Failed to convert the digest"
-
-    --> Hex string: 2088DF74D5F2146B48146CAF4965377E9D0BE3A4
+    toHex (digest "key" "message")
+    --> Ok "2088DF74D5F2146B48146CAF4965377E9D0BE3A4"
 
 -}
 toHex : Digest -> Result String String

--- a/src/HmacSha1.elm
+++ b/src/HmacSha1.elm
@@ -23,7 +23,7 @@ import SHA1
 import Word.Bytes as Bytes
 
 
-{-| A HMAC-SHA1 digest.
+{-| An HMAC-SHA1 digest.
 -}
 type Digest
     = Digest (List Int)

--- a/src/HmacSha1.elm
+++ b/src/HmacSha1.elm
@@ -1,6 +1,6 @@
 module HmacSha1 exposing
     ( Digest, digest
-    , toBytes, toIntList, toHex, toBase64
+    , toBytes, toByteValues, toHex, toBase64
     )
 
 {-| Computes a Hash-based Message Authentication Code (HMAC) using the SHA-1 hash function
@@ -10,7 +10,7 @@ module HmacSha1 exposing
 
 # Representation
 
-@docs toBytes, toIntList, toHex, toBase64
+@docs toBytes, toByteValues, toHex, toBase64
 
 -}
 
@@ -64,15 +64,19 @@ toBytes (Digest data) =
     SHA1.toBytes data
 
 
-{-| Convert a Digest into a List of Integers. Sometimes you will want to have the
-Byte representation as a list of integers.
+{-| Convert a Digest into a List of Integers. Each Integer is in the range
+0-255, and represents one byte. Can be useful for passing digest on to other
+packages that make use of this convention.
 
-    toIntList (digest "key" "message")
+    import HmacSha1.Key as Key
+
+    fromString (Key.fromString "key") "message"
+        |> toByteValues
     --> [32, 136, 223, 116, 213, 242, 20, 107, 72, 20, 108, 175, 73, 101, 55, 126, 157, 11, 227, 164]
 
 -}
-toIntList : Digest -> List Int
-toIntList (Digest data) =
+toByteValues : Digest -> List Int
+toByteValues (Digest data) =
     SHA1.toByteValues data
 
 

--- a/src/HmacSha1/Key.elm
+++ b/src/HmacSha1/Key.elm
@@ -1,0 +1,34 @@
+module HmacSha1.Key exposing (Key, fromBytes, fromString)
+
+import Bytes exposing (Bytes)
+import Bytes.Encode as Encode
+import Internals as I
+import SHA1
+
+
+type alias Key =
+    I.Key
+
+
+fromString : String -> Key
+fromString =
+    fromBytes << Encode.encode << Encode.string
+
+
+fromBytes : Bytes -> Key
+fromBytes bytes =
+    let
+        ints =
+            if Bytes.width bytes > blockSize then
+                SHA1.fromBytes bytes
+                    |> SHA1.toByteValues
+
+            else
+                I.bytesToInts bytes
+    in
+    I.Key (ints ++ List.repeat (blockSize - List.length ints) 0)
+
+
+blockSize : Int
+blockSize =
+    64

--- a/src/Internals.elm
+++ b/src/Internals.elm
@@ -1,0 +1,30 @@
+module Internals exposing (Key(..), bytesToInts, stringToInts)
+
+import Bytes exposing (Bytes)
+import Bytes.Decode as Decode
+import Bytes.Encode as Encode
+
+
+type Key
+    = Key (List Int)
+
+
+bytesToInts : Bytes -> List Int
+bytesToInts bytes =
+    let
+        decoder acc width =
+            if width == 0 then
+                Decode.succeed (List.reverse acc)
+
+            else
+                Decode.unsignedInt8
+                    |> Decode.andThen (\int -> decoder (int :: acc) (width - 1))
+    in
+    bytes
+        |> Decode.decode (decoder [] (Bytes.width bytes))
+        |> Maybe.withDefault []
+
+
+stringToInts : String -> List Int
+stringToInts =
+    Encode.string >> Encode.encode >> bytesToInts

--- a/tests/HmacSha1Test.elm
+++ b/tests/HmacSha1Test.elm
@@ -14,23 +14,23 @@ suite =
                 \_ ->
                     digest "" ""
                         |> toBase64
-                        |> Expect.equal (Ok "+9sdGxiqbAgyS31ktx+3Y3BpDh0=")
+                        |> Expect.equal "+9sdGxiqbAgyS31ktx+3Y3BpDh0="
             , test "key: key, message: message" <|
                 \_ ->
                     digest "key" "message"
                         |> toBase64
-                        |> Expect.equal (Ok "IIjfdNXyFGtIFGyvSWU3fp0L46Q=")
+                        |> Expect.equal "IIjfdNXyFGtIFGyvSWU3fp0L46Q="
             ]
         , describe "HmacSha1.toHex"
             [ test "empty key and message" <|
                 \_ ->
                     digest "" ""
                         |> toHex
-                        |> Expect.equal (Ok "FBDB1D1B18AA6C08324B7D64B71FB76370690E1D")
+                        |> Expect.equal "fbdb1d1b18aa6c08324b7d64b71fb76370690e1d"
             , test "key: key, message: message" <|
                 \_ ->
                     digest "key" "message"
                         |> toHex
-                        |> Expect.equal (Ok "2088DF74D5F2146B48146CAF4965377E9D0BE3A4")
+                        |> Expect.equal "2088df74d5f2146b48146caf4965377e9d0be3a4"
             ]
         ]

--- a/tests/HmacSha1Test.elm
+++ b/tests/HmacSha1Test.elm
@@ -3,6 +3,7 @@ module HmacSha1Test exposing (suite)
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
 import HmacSha1 exposing (..)
+import HmacSha1.Key as Key
 import Test exposing (..)
 
 
@@ -12,24 +13,24 @@ suite =
         [ describe "HmacSha1.toBase64"
             [ test "empty key and message" <|
                 \_ ->
-                    digest "" ""
+                    fromString (Key.fromString "") ""
                         |> toBase64
                         |> Expect.equal "+9sdGxiqbAgyS31ktx+3Y3BpDh0="
             , test "key: key, message: message" <|
                 \_ ->
-                    digest "key" "message"
+                    fromString (Key.fromString "key") "message"
                         |> toBase64
                         |> Expect.equal "IIjfdNXyFGtIFGyvSWU3fp0L46Q="
             ]
         , describe "HmacSha1.toHex"
             [ test "empty key and message" <|
                 \_ ->
-                    digest "" ""
+                    fromString (Key.fromString "") ""
                         |> toHex
                         |> Expect.equal "fbdb1d1b18aa6c08324b7d64b71fb76370690e1d"
             , test "key: key, message: message" <|
                 \_ ->
-                    digest "key" "message"
+                    fromString (Key.fromString "key") "message"
                         |> toHex
                         |> Expect.equal "2088df74d5f2146b48146caf4965377e9d0be3a4"
             ]

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -1,0 +1,4 @@
+{
+  "root": "../src",
+  "tests": ["./README.md", "HmacSha1"]
+}


### PR DESCRIPTION
Hey,

I was able to do the work this morning. I've tried to split the commits up into as many logical parts as I can, but 11b90b8 is the main one.

I think it's made about a 20% performance increase, from rough testing.

The changes mean that there were a couple of unnecessary dependencies, and also that the type signatures of `toHex` and `toBase64` changed (for the better, I think). I left those changes till the final commits.

As the changes to `toHex` and `toBase64` mean a major version change anyway, I wanted to ask what you think about renaming `toIntList`? In the rewrite of elm-sha1, @folkertdev went for `toByteValues`, which I think is good — it describes what the `List Int` actually represents, so it gives it better meaning.